### PR TITLE
Fixed "trim(): Passing null to parameter #1 ... is deprecated"

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -40,7 +40,7 @@ class Gateway extends AbstractGateway
         OpenPayU_Configuration::setOauthGrantType('client_credentials');
         OpenPayU_Configuration::setMerchantPosId($this->getParameter('posId'));
         OpenPayU_Configuration::setSignatureKey($this->getParameter('secondKey'));
-        OpenPayU_Configuration::setOauthClientId($this->getParameter('posAuthKey'));
+        OpenPayU_Configuration::setOauthClientId($this->getParameter('posAuthKey') ?? '');
         OpenPayU_Configuration::setOauthClientSecret($this->getParameter('clientSecret'));
 
         return $this;


### PR DESCRIPTION
The parameter ``posAuthKey`` accepts ``null`` (and ``null`` is a default value). However, ``OpenPayU_Configuration::setOauthClientId()`` only accepts strings (the argument is passed to ``trim()``). 

This caused:

```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/openpayu/openpayu_php_sdk/lib/OpenPayU/Configuration.php on line 248
```